### PR TITLE
Automatic installation of ASE

### DIFF
--- a/blender_importASE/__init__.py
+++ b/blender_importASE/__init__.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 
 import bpy
+import sys
+import subprocess
 from bpy_extras.io_utils import ImportHelper
 from os.path import join
-from .ui import import_ase_molecule
+
 
 
 __author__ = "Hendrik Weiske"
@@ -150,7 +152,7 @@ class ImportASEMolecule(bpy.types.Operator, ImportHelper):
             # this section causes the representation to be ignored when overwrite is checked
             # we should come up with something else for now set default to false
 
-            
+
             import_ase_molecule(filepath, file.name,
                             
                                 resolution=self.resolution,
@@ -167,12 +169,19 @@ class ImportASEMolecule(bpy.types.Operator, ImportHelper):
         context.window_manager.fileselect_add(self)
         return {'RUNNING_MODAL'}
 
+def make_install():
+    python_path = sys.executable
+    install_path = bpy.utils.script_path_user()
+    subprocess.check_call([python_path, "-m", "pip", "install","--target", install_path, "ase"])
+    print("Installed ASE, ready to register")
+
 
 def menu_func_import(self, context):
     self.layout.operator(ImportASEMolecule.bl_idname, text="ASE Molecule (.*)")
 
 
 def register():
+    make_install()
     bpy.utils.register_class(ImportASEMolecule)
     bpy.types.TOPBAR_MT_file_import.append(menu_func_import)
 
@@ -184,3 +193,4 @@ def unregister():
 
 if __name__ == "__main__":
     register()
+    from .ui import import_ase_molecule


### PR DESCRIPTION
Small changes that allow for the automatic installation of ASE into Blender when the Ad-on is installed from the zip file. 
Works system system agnostic but still needs testing on Windows and MacOS 