### PR TITLE
fix: bugfix branch (outline material, color lookup, openvdb)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ testmaterials.xyz
 write_colors.py
 *.zip
 
+\n# Local dev tools (home-specific)\ntest_pipeline.py

--- a/.gitignore
+++ b/.gitignore
@@ -171,4 +171,3 @@ testmaterials.xyz
 write_colors.py
 *.zip
 
-\n# Local dev tools (home-specific)\ntest_pipeline.py

--- a/blender_importASE/import_cubefiles.py
+++ b/blender_importASE/import_cubefiles.py
@@ -7,7 +7,10 @@ from ase.io.cube import read_cube
 try:
     import openvdb as vdb
 except ImportError:
-    import pyopenvdb as vdb
+    try:
+        import pyopenvdb as vdb
+    except ImportError:
+        vdb = None
 import os
 from .node_networks.electron_density_nodes import visualize_edensity_node_group
 from .utils import toggle

--- a/blender_importASE/import_cubefiles.py
+++ b/blender_importASE/import_cubefiles.py
@@ -18,6 +18,11 @@ import os.path
 
 
 def cube2vol(filename, filepath=os.environ.get('HOME'),modifier='GeometryNodes'):
+    if vdb is None:
+        raise ImportError(
+            "Neither 'openvdb' nor 'pyopenvdb' is installed. "
+            "Please install one of them to import volumetric density files."
+        )
     with open(filename, 'r') as f:
         atoms = read_cube(f, read_data=True, verbose=True)
         ORIGIN = atoms['origin']

--- a/blender_importASE/node_networks/outline.py
+++ b/blender_importASE/node_networks/outline.py
@@ -85,7 +85,8 @@ def outline_node_group(mat=None):
     # Node Normal
     normal = outline.nodes.new("GeometryNodeInputNormal")
     normal.name = "Normal"
-    normal.legacy_corner_normals = True
+    if hasattr(normal, 'legacy_corner_normals'):
+        normal.legacy_corner_normals = True
 
     # Node Group Input
     group_input = outline.nodes.new("NodeGroupInput")

--- a/blender_importASE/node_networks/outline.py
+++ b/blender_importASE/node_networks/outline.py
@@ -157,8 +157,6 @@ def outline_node_group(mat=None):
     return outline
 
 
-outline = outline_node_group()
-
 
 def outline_color_node_group(mat):
 
@@ -278,6 +276,8 @@ def outline_objects(list_of_objects,modifier='GeometryNodes'):
             node = outline_node_group(mat=mat)
     else:
         node = outline_node_group(mat=mat)
+    # Always ensure the material socket is set correctly
+    node.interface.items_tree["Outline-Mat"].default_value = mat
 
     node["Socket_1"] = 1
     node["Socket_2"] = False

--- a/blender_importASE/utils.py
+++ b/blender_importASE/utils.py
@@ -165,7 +165,7 @@ class atomcolors():
                 if atom_type in self.color_dict:
                     COL=list(self.color_dict[atom_type]) + [1]
                 else:
-                    COL=list(colors.jmol_colors[atom_n[n]]) + [1]
+                    COL=list(colors.jmol_colors[atomic_numbers[atom_type]]) + [1]
                 if atom_type in self.metal_dict:
                     metal=self.metal_dict[atom_type]
                 else:


### PR DESCRIPTION
This branch fixes several bugs:

- **Outline material socket**: The `outline_color` material was never correctly set in the geometry node group socket when the node group already existed. Also removed the module-level `outline_node_group()` call that ran at import time with `mat=None`.
- **Blender 4.3 compatibility**: Guard `legacy_corner_normals` with `hasattr` so it doesn't crash on Blender <4.4.
- **Color lookup IndexError**: `setup_materials` was using `atom_n[n]` (index-based) for the fallback color lookup, which goes out of range when `'Gray'` is added to `atom_types` but not to `atom_n`. Fixed to use `atomic_numbers[atom_type]` consistently.
- **openvdb import**: Gracefully handle missing `openvdb` and `pyopenvdb` instead of crashing at module load.