### PR TITLE
fix: remove duplicate and unused imports flagged by ruff

### DIFF
--- a/blender_importASE/node_networks/nodes_atoms_and_bonds.py
+++ b/blender_importASE/node_networks/nodes_atoms_and_bonds.py
@@ -3,9 +3,6 @@ import numpy as np
 from ..utils import atomcolors
 from ase.data import covalent_radii, chemical_symbols, colors, vdw_alvarez
 
-import bpy
-import mathutils
-import os
 import typing
 
 


### PR DESCRIPTION
## Summary
- Hotfix to restore CI on `main`.
- Drops a duplicate `import bpy` and unused `import mathutils` / `import os` in `blender_importASE/node_networks/nodes_atoms_and_bonds.py`, introduced by #11.

Failing run: https://github.com/Tonner-Zech-Group/blender-importASE/actions/runs/25313756246
Errors: `F811` (duplicate `bpy`), `F401` (unused `mathutils`, `os`).

## Test plan
- [x] `ruff check --no-cache .` → All checks passed locally
- [x] File still parses (`python -c "import ast; ast.parse(open(...).read())"`)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)