### PR TITLE
fix: drop orphaned atom_n assignment flagged by ruff

### DIFF
--- a/blender_importASE/utils.py
+++ b/blender_importASE/utils.py
@@ -136,7 +136,6 @@ class atomcolors():
     
     def setup_materials(self,atoms,colorbonds=False):
         atom_types = set(atoms.get_chemical_symbols())
-        atom_n=list(set(atoms.numbers))
         atom_types.add('Gray')
         bpy.ops.object.select_all(action='DESELECT')
         bpy.ops.mesh.primitive_uv_sphere_add(location=(0,0,0),segments = 16 ,ring_count = 16)


### PR DESCRIPTION
## Summary
- Second hotfix to restore CI on `main`.
- Removes the now-orphaned `atom_n = list(set(atoms.numbers))` in `setup_materials` (`blender_importASE/utils.py:139`).

The read of `atom_n[n]` was replaced with `atomic_numbers[atom_type]` in #12 (a correct fix — `set→list` ordering was undefined, so colors could be misassigned). That change left the assignment dead, which ruff 0.15.12 flags as `F841`.

Failing run: https://github.com/Tonner-Zech-Group/blender-importASE/actions/runs/25315544254

## Test plan
- [x] `ruff check --no-cache .` → All checks passed locally
- [x] File still parses (`python -c "import ast; ast.parse(open(...).read())"`)
- [x] Confirmed `atomic_numbers` is imported (line 2) and used at lines 169, 228, 262 — no other code path depended on `atom_n`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)