### PR TITLE
chore: release v2.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 - family-names: "Thiemann"
   given-names: "Franz"
 title: "Blender Import ASE"
-version: 2.2
+version: "2.2"
 doi: 10.5281/zenodo.10776696
 date-released: 2026-05-04
 url: "https://github.com/Tonner-Zech-Group/blender-importASE"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 - family-names: "Thiemann"
   given-names: "Franz"
 title: "Blender Import ASE"
-version: 1.3.0
+version: 2.2
 doi: 10.5281/zenodo.10776696
-date-released: 2024-03-04
+date-released: 2026-05-04
 url: "https://github.com/Tonner-Zech-Group/blender-importASE"

--- a/blender_importASE/__init__.py
+++ b/blender_importASE/__init__.py
@@ -11,7 +11,7 @@ from importlib import util
 
 __author__ = "Hendrik Weiske"
 __credits__ = ["Franz Thiemann"]
-__version__ = "2.1" 
+__version__ = "2.2"
 __maintainer__ = "Hendrik Weiske"
 __email__ = "hendrik.weiske@uni-leipzig.de"
 
@@ -19,7 +19,7 @@ bl_info = {
     "name": "ASE Importer",
     "description": "Import molecules using ASE",
     "author": "Hendrik Weiske",
-    "version": (2, 1),
+    "version": (2, 2),
     "blender": (4, 4, 0),
     "location": "File > Import",
     "category": "Import-Export",


### PR DESCRIPTION
## Summary
Version bump for v2.2 release.

- `__version__` → `"2.2"`
- `bl_info["version"]` → `(2, 2)`
- `CITATION.cff` version → `2.2`, date-released → `2026-05-04`
- CITATION DOI unchanged (it's the Zenodo concept DOI, resolves to latest)

## Release notes (for the GitHub release after merge)

### Features
* Add per-element radius mode switching (covalent/vdW) via Menu Switch nodes by @hweiske in #11

### Fixes
* Outline material, color lookup, openvdb guard by @patrickmelix in #12
  - Color lookup is now deterministic across runs for elements outside the custom color dict (previously misassigned due to set-ordering)
* Fall back to `self.filepath` when `self.files` is empty in `execute()` by @patrickmelix in #10
* Remove duplicate and unused imports flagged by ruff in #13
* Drop orphaned `atom_n` assignment flagged by ruff in #14

### Tests
* Cover programmatic and dialog-shape import operator calls by @patrickmelix in #10

> **Note:** v2.2 is the last planned release on the Blender 4.4+ rolling track. The next release will pin to a Blender LTS series.

**Full Changelog**: https://github.com/Tonner-Zech-Group/blender-importASE/compare/v2.1...v2.2

## Test plan
- [x] `bl_info` and `__version__` updated consistently
- [x] CITATION.cff version + date-released bumped
- [ ] CI green on this PR
- [ ] After merge: tag `v2.2`, build addon zip, create GitHub release with notes above

🤖 Generated with [Claude Code](https://claude.com/claude-code)