### PR TITLE
ci: pin ruff, add merge_group trigger and release workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -7,6 +7,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
 
 permissions:
   contents: read
@@ -28,7 +29,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with Ruff
       run: |
-        pip install ruff
+        pip install ruff==0.15.12
         ruff check --output-format=github .
       continue-on-error: false
     - name: Test with pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+# Builds the addon zip and creates/updates a GitHub release on tag push.
+# Trigger by pushing a tag that starts with `v` (e.g. `git tag v2.3 && git push origin v2.3`).
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build addon zip
+      run: |
+        zip -r blender_importASE.zip blender_importASE \
+          -x "*/__pycache__/*" "*.pyc" "*/.pytest_cache/*" "*/.ruff_cache/*"
+
+    - name: Create or update GitHub release
+      uses: softprops/action-gh-release@v2
+      with:
+        generate_release_notes: true
+        files: |
+          blender_importASE.zip
+          render_vpts.py


### PR DESCRIPTION
## Summary

Three small CI hardening changes that address concrete pain points hit during the v2.2 release:

### 1. Pin ruff to 0.15.12
A new ruff release adding default rules can otherwise flip CI red overnight without an explicit bump (the v2.1→v2.2 cycle saw exactly this pattern, where ruff 0.15.12's tighter defaults turned PR #11 and PR #12 into post-merge failures on `main`).

### 2. Add `merge_group:` trigger
Tests run on the tentative merge commit if/when GitHub merge queues are enabled in branch protection. **No-op until merge queues are turned on**, so this is safe to land on its own. Catches the "PR green / `main` red" pattern from #11 and #12.

### 3. New `.github/workflows/release.yml`
Builds the addon zip and creates/updates a GitHub release on `v*` tag push. Replaces the manual zipfile build done for v2.2:

- Triggered by pushing a tag matching `v*`.
- Excludes `__pycache__/`, `*.pyc`, `.pytest_cache/`, `.ruff_cache/` from the zip.
- Uses `softprops/action-gh-release@v2` with `generate_release_notes: true`.
- Attaches `blender_importASE.zip` and `render_vpts.py`.

After merge, the next release is just `git tag v2.3 && git push origin v2.3` — workflow does the rest.

## Test plan
- [x] YAML parses for both files
- [ ] CI green on this PR (validates the pinned ruff still passes)
- [ ] Manual smoke after merge: push a throwaway tag like `v2.2-test` then delete, verify the release workflow runs (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)